### PR TITLE
Fix typo in psq/task.py

### DIFF
--- a/psq/task.py
+++ b/psq/task.py
@@ -51,7 +51,7 @@ class Task(object):
     def reset(self):
         self.status = QUEUED
         self.result = None
-        self.retires = 0
+        self.retries = 0
 
     def retry(self):
         self.status = RETRYING


### PR DESCRIPTION
Hi there, 

I found a small typo reading the `task.py` file.
The `reset()` function try to set `self.retires` to 0, instead of `self.retries`.

Cheers