### PR TITLE
if queue is a function, call it to get the queue object

### DIFF
--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -51,6 +51,8 @@ def import_queue(location):
     module, attr = location.rsplit('.', 1)
     module = import_module(module)
     queue = getattr(module, attr)
+    if hasattr(queue, '__call__'):
+    	queue = queue()
     return queue
 
 

--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -52,7 +52,7 @@ def import_queue(location):
     module = import_module(module)
     queue = getattr(module, attr)
     if hasattr(queue, '__call__'):
-    	queue = queue()
+        queue = queue()
     return queue
 
 


### PR DESCRIPTION
It may be necessary to perform setup prior to returning the queue object. This PR tests the <module>.queue.queue entity to see if it is a function rather than an object; if it is a function, call it to get the queue object.