### PR TITLE
Support for Late Acks to extend the timeout of a task being executed

### DIFF
--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -51,6 +51,8 @@ def import_queue(location):
     module, attr = location.rsplit('.', 1)
     module = import_module(module)
     queue = getattr(module, attr)
+    if hasattr(queue, '__call__'):
+    	queue = queue()
     return queue
 
 

--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -52,7 +52,7 @@ def import_queue(location):
     module = import_module(module)
     queue = getattr(module, attr)
     if hasattr(queue, '__call__'):
-    	queue = queue()
+        queue = queue()
     return queue
 
 


### PR DESCRIPTION
If a long timeout is set for a long-running task but the task is interrupted prior to completion, it won't be restarted for some time. At the other extreme, if a short timeout is set, a long-running task will be considered incomplete and re-started with another worker. Support for extending timeouts during task execution exists in PubSub, this library should have a way to perform this late_ack.

Note that no code has been changed yet. This PR is simply a placeholder for discussing the feature and eventual implementation.