### PR TITLE
Fix StatusCode.DEADLINE_EXCEEDED when dequeuing an empty queue

### DIFF
--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -73,7 +73,10 @@ def import_queue(location):
     'queue',
     nargs=1,
     required=True)
-def main(path, single_threaded, workers, pid, queue):
+@click.option(
+    '--empty-delay', default=0, type=click.FLOAT,
+    help='Sleep time if queue is empty upon pulling.')
+def main(path, single_threaded, workers, pid, queue, empty_delay):
     """
     Standalone PSQ worker.
 
@@ -107,11 +110,12 @@ def main(path, single_threaded, workers, pid, queue):
     import psq
 
     if single_threaded:
-        worker = psq.Worker(queue=queue)
+        worker = psq.Worker(queue=queue, empty_delay=empty_delay)
     else:
         worker = psq.MultiprocessWorker(
             queue=queue,
-            num_workers=workers)
+            num_workers=workers,
+            empty_delay=empty_delay)
 
     worker.listen()
 


### PR DESCRIPTION
When task queue is empty and worker is meant to block, PubSub RPC pull can result in `StatusCode.DEADLINE_EXCEEDED`. I still haven't found a consistent way to force the failure, but eventually it always happens.

This fix allows psqworker to have a custom sleep time (default to 0) when dequeuing an empty queue. If no value is provided, or value is 0, `dequeue` will keep blocking as it does now.