### PR TITLE
Fix enqueuing tasks with strings in synchronous mode

### DIFF
--- a/psq/queue.py
+++ b/psq/queue.py
@@ -101,10 +101,13 @@ class Queue(object):
             self.topic.publish(data)
             logger.info('Task {} queued.'.format(task.id))
         else:
-            logger.info('Executing task {} synchronously.'.format(task.id))
+            unpickled_task = unpickle(data)
+            logger.info(
+                'Executing task {} synchronously.'.format(unpickled_task.id)
+            )
             with measure_time() as summary, self.queue_context():
-                task.execute(queue=self)
-                summary(task.summary())
+                unpickled_task.execute(queue=self)
+                summary(unpickled_task.summary())
 
         return TaskResult(task.id, self)
 

--- a/psq/queue_test.py
+++ b/psq/queue_test.py
@@ -42,6 +42,10 @@ class TestStorage(object):
         self._data[task.id] = task
 
 
+def dummy_queue_func():
+    return "Hello"
+
+
 def test_creation():
     # Test the case where queue needs to create the topic.
     pubsub = Mock()
@@ -222,3 +226,9 @@ def test_synchronous_fail():
     r = q.enqueue(sum, "2")
     with pytest.raises(TypeError):
         r.result()
+
+
+def test_string_function():
+    q = Queue(pubsub=None, storage=TestStorage(), async=False)
+    r = q.enqueue('psq.queue_test.dummy_queue_func')
+    assert r.result() == "Hello"


### PR DESCRIPTION
Currently if you enqueue a task by its string path on a queue with `async=False`, you encounter an AttributeError, because the function isn't imported until the task is pickled/unpickled. `Task.execute` will also not behave as expected.

For example, this will throw an error, even if `'tasks.some_task'` is a path to a real function:
```
q = psq.Queue(None, async=False, storage=TestStorage())
r = q.enqueue('tasks.some_task', 'some_arg')
```

This PR makes queues with `async=False` treat tasks the same whether defined with strings or functions.