### PR TITLE
[Feature] Late acknowledgement support for queues.

### DIFF
--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -69,14 +69,11 @@ def import_queue(location, **kwargs):
 @click.option(
     '--pid',
     help='Write the process ID to the specified file.')
-@click.option(
-    '--late_ack',
-    help='Enable late acknowledgement after this task has been executed.')
 @click.argument(
     'queue',
     nargs=1,
     required=True)
-def main(path, single_threaded, workers, pid, queue, late_ack):
+def main(path, single_threaded, workers, pid, queue):
     """
     Standalone PSQ worker.
 
@@ -106,7 +103,7 @@ def main(path, single_threaded, workers, pid, queue, late_ack):
     sys.path.insert(0, path)
 
     # init queue object
-    queue = import_queue(queue, late_ack=late_ack)
+    queue = import_queue(queue)
 
     import psq
 

--- a/psq/psqworker.py
+++ b/psq/psqworker.py
@@ -47,12 +47,12 @@ def setup_logging():  # pragma: no cover
     root_logger.addHandler(handler)
 
 
-def import_queue(location):
+def import_queue(location, **kwargs):
     module, attr = location.rsplit('.', 1)
     module = import_module(module)
     queue = getattr(module, attr)
     if hasattr(queue, '__call__'):
-        queue = queue()
+        queue = queue(**kwargs)
     return queue
 
 
@@ -69,11 +69,14 @@ def import_queue(location):
 @click.option(
     '--pid',
     help='Write the process ID to the specified file.')
+@click.option(
+    '--late_ack',
+    help='Enable late acknowledgement after this task has been executed.')
 @click.argument(
     'queue',
     nargs=1,
     required=True)
-def main(path, single_threaded, workers, pid, queue):
+def main(path, single_threaded, workers, pid, queue, late_ack):
     """
     Standalone PSQ worker.
 
@@ -102,7 +105,8 @@ def main(path, single_threaded, workers, pid, queue):
 
     sys.path.insert(0, path)
 
-    queue = import_queue(queue)
+    # init queue object
+    queue = import_queue(queue, late_ack=late_ack)
 
     import psq
 

--- a/psq/queue.py
+++ b/psq/queue.py
@@ -96,7 +96,6 @@ class Queue(object):
 
         Note that this does not store the task.
         """
-        # make sure
         data = task.dump()
 
         if self._async:

--- a/psq/task.py
+++ b/psq/task.py
@@ -20,7 +20,7 @@ import time
 
 from six import string_types
 
-from src.psq.utils import dumps
+from .utils import dumps
 from .globals import current_queue, task_context
 
 

--- a/psq/task.py
+++ b/psq/task.py
@@ -20,8 +20,8 @@ import time
 
 from six import string_types
 
-from .utils import dumps
 from .globals import current_queue, task_context
+from .utils import dumps
 
 
 logger = logging.getLogger(__name__)
@@ -56,7 +56,8 @@ class Task(object):
         self.retries = 0
         self.reset()
 
-        # these values will be set on dequeue if late acknowledgement is configured
+        # these values will be set on dequeue if late acknowledgement
+        # is configured
         self.subscription = None
         """ :type: None|google.cloud.pubsub.Subscription """
         self.ack_id = ''
@@ -83,10 +84,12 @@ class Task(object):
         self.result = exception
 
     def acknowledge(self):
-        """Acknowledge that this task was completed. Used for tasks that were dequeued with a late_ack-enabled queue.
+        """Acknowledge that this task was completed. Used for tasks
+        that were dequeued with a late_ack-enabled queue.
 
-        :return: Returns `True` if late acknowledgement was required and has been done, `False` otherwise
-        :rtype: bool
+        Returns:
+            bool: Returns `True` if late acknowledgement was required
+            and has been done, `False` otherwise
 
         """
         if self.ack_id:
@@ -98,7 +101,8 @@ class Task(object):
     def dump(self):
         """ Get prepared task data for enqueuing.
 
-        :rtype: six.basestring
+        Returns:
+            six.string_types: serialized instance of Task
         """
 
         # make sure we don't dump complex data
@@ -106,7 +110,7 @@ class Task(object):
         if self.ack_id:
             self.ack_id, self.subscription = '', None
 
-        # fixme: (u)json support to improve compatibility with non-python clients (and speedup py2)
+        # fixme: (u)json support
         data = dumps(self)
 
         # restore data


### PR DESCRIPTION
Hey there,

thanks for this package! We are currently evaluating psq as a pub/sub quickstart after being forced to use the flexible environment (good-bye Task Queue :( ). 

This is a first implementation, happy to get some feedback from you. I had the wrong concept in mind when creating the first commit (celery workers just receive a queue name / queue names to listen to, psq requires a Queue subclass/instance if you want to make changes to the runtime configuration.

Question: can we safely move the call to `self.topic = self._get_or_create_topic()` in `Queue.__init__` to `Queue._get_or_create_subscription` in order to enable lazy connections in async mode? (I would put that into another PR)

I see a problem in creating dozens of queues in the same file and making way too many cloud calls when importing just one queue :-)

We probably will contribute additional functionality down the road, feel free to give us ideas / hints where you want this project to go:
- bulk enqueue (short-term)
- changing the way the function is imported
    - cache the function import (short-term)
    - (u)json support to easen access to the data payload for non-python apps (mid-term) [this also improves (de)serialization times for older python versions, but I admit, I was quite surprised to learn about pickle's performance in 3.5]

