### PR TITLE
Python3.7 compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -230,13 +230,13 @@ Bypassing workers for testing
 
 During unit tests you most certainly don't want to spin up workers, but instead
 execute the enqueued functions immediately and synchronously. To do this, pass
-`async=False` to the Queue's constructor (default is True). Also, you don't have
+`asynchronous=False` to the Queue's constructor (default is True). Also, you don't have
 to provide a publisher, subscriber or project arguments in this case,
 just pass None for all them to the queue.
 
 .. code:: python
 
-    q = psq.Queue(None, None, project=None, async=False)
+    q = psq.Queue(None, None, project=None, asynchronous=False)
     r = q.enqueue(adder, 1, 2) # Will be run immediately
 
 

--- a/psq/queue.py
+++ b/psq/queue.py
@@ -34,7 +34,8 @@ PUBSUB_OBJECT_PREFIX = 'psq'
 
 class Queue(object):
     def __init__(self, publisher_client, subscriber_client, project,
-                 name='default', storage=None, extra_context=None, asynchronous=True):
+                 name='default', storage=None, extra_context=None,
+                 asynchronous=True):
         self._async = asynchronous
         self.name = name
         self.project = project

--- a/psq/queue.py
+++ b/psq/queue.py
@@ -34,8 +34,8 @@ PUBSUB_OBJECT_PREFIX = 'psq'
 
 class Queue(object):
     def __init__(self, publisher_client, subscriber_client, project,
-                 name='default', storage=None, extra_context=None, async=True):
-        self._async = async
+                 name='default', storage=None, extra_context=None, asynchronous=True):
+        self._async = asynchronous
         self.name = name
         self.project = project
 

--- a/psq/queue_test.py
+++ b/psq/queue_test.py
@@ -228,19 +228,19 @@ def test_cleanup():
 
 
 def test_synchronous_success():
-    q = make_queue(storage=TestStorage(), async=False)
+    q = make_queue(storage=TestStorage(), asynchronous=False)
     r = q.enqueue(sum, [1, 2])
     assert r.result() == 3
 
 
 def test_synchronous_fail():
-    q = make_queue(storage=TestStorage(), async=False)
+    q = make_queue(storage=TestStorage(), asynchronous=False)
     r = q.enqueue(sum, "2")
     with pytest.raises(TypeError):
         r.result()
 
 
 def test_string_function():
-    q = make_queue(storage=TestStorage(), async=False)
+    q = make_queue(storage=TestStorage(), asynchronous=False)
     r = q.enqueue('psq.queue_test.dummy_queue_func')
     assert r.result() == "Hello"


### PR DESCRIPTION
Change async to asynchronous because async is a keyword in python3.7.

Resolves #40.