### PR TITLE
Autospec Task in the worker test.

### DIFF
--- a/psq/worker_test.py
+++ b/psq/worker_test.py
@@ -14,6 +14,7 @@
 
 import mock
 from psq.queue import dummy_context, Queue
+from psq.task import Task
 from psq.worker import Worker
 
 
@@ -39,7 +40,7 @@ def test_worker_listen():
     q = MockQueue()
     worker = Worker(queue=q)
 
-    t = mock.Mock()
+    t = mock.create_autospec(Task, instance=True)
     q.enqueue_task(t)
 
     worker.listen()


### PR DESCRIPTION
I think it's always best to use [autospec](https://medium.com/python-pandemonium/mocking-has-a-weakness-speccing-removes-it-2d2068a17df8).