### PR TITLE
Update datastore version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
 
     install_requires=[
         'google-cloud-pubsub>=0.35.2',
-        'google-cloud-datastore>=1.0.0,<=2.0.0',
+        'google-cloud-datastore>=1.0.0,<=2.0.1',
         'werkzeug>=0.10.0,<1.0.0',
         'click>=4.0',
         'colorlog>=2.6.0,<3.0.0'],


### PR DESCRIPTION
The difference between 2.0.0 and 2.0.1 is very minor (https://github.com/googleapis/python-datastore/releases/tag/v2.0.1), so shouldn't cause any compatibility issues.